### PR TITLE
chore: add vscode metadata to code cells

### DIFF
--- a/00-preliminaries.ipynb
+++ b/00-preliminaries.ipynb
@@ -106,7 +106,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "8a146db6-2058-4143-b4ec-043349088956",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -135,7 +139,10 @@
    "execution_count": 2,
    "id": "5a348df2-cb70-4cad-8df6-c932b7d4eb50",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -155,7 +162,10 @@
    "execution_count": 3,
    "id": "e22d9fad-294c-42e1-9307-10edb8f02dfc",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -230,7 +240,10 @@
    "execution_count": 4,
    "id": "386bcb2d-be2d-4346-9657-04d3f4655360",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -279,7 +292,10 @@
    "execution_count": 5,
    "id": "7d20a1cd-805b-44b1-90a0-2f934dbc4bf6",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -328,7 +344,10 @@
    "execution_count": 6,
    "id": "ee183195-ebe5-4d37-b43b-89100bc6dfc6",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -361,7 +380,10 @@
    "execution_count": 7,
    "id": "7f29d0f3-c4db-45e5-8748-ce0a72c08eca",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -403,10 +425,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "9ec08694-8c4f-4a83-acbf-fe71acd715c2",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -461,7 +486,10 @@
    "execution_count": 9,
    "id": "8bb867d3-f099-4ce9-8411-af904024e729",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -482,7 +510,10 @@
    "execution_count": 10,
    "id": "d3b8e993-a6c8-4307-a8f7-772b15d37731",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -507,7 +538,10 @@
    "execution_count": 11,
    "id": "1f8ede90-4c8d-4c97-a449-36e7a37aca42",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -542,7 +576,10 @@
    "execution_count": 12,
    "id": "c66c378f-34f8-484f-acc7-200a40fb2468",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -563,7 +600,10 @@
    "execution_count": 13,
    "id": "e0be461f-2399-4b28-a0c6-21966383bafd",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -588,7 +628,10 @@
    "execution_count": 14,
    "id": "67e73e10-0d09-4c8f-b4d0-07ccc34f11cb",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -623,7 +666,10 @@
    "execution_count": 15,
    "id": "7a4cfdc0-0150-428d-b242-b463dea5a0c7",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -644,7 +690,10 @@
    "execution_count": 16,
    "id": "540e6045-d92c-49da-af39-cd339a5963b0",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -669,7 +718,10 @@
    "execution_count": 17,
    "id": "6ed6137d-b9fe-4a87-b0a4-f2b802fa96e4",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -704,7 +756,10 @@
    "execution_count": 18,
    "id": "89967b6a-01a0-42a6-ba70-258f67a2ddba",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -725,7 +780,10 @@
    "execution_count": 19,
    "id": "81238600-8ae9-43fd-881f-5bb1ab85688d",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -750,7 +808,10 @@
    "execution_count": 20,
    "id": "16cd8dd9-153c-4abc-903e-a91e742044ca",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -789,7 +850,10 @@
    "execution_count": 21,
    "id": "73e739b1-9d2f-4f36-b1ce-24e9e6c88f4b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -819,7 +883,10 @@
    "execution_count": 22,
    "id": "7c2069be-6817-4193-90bf-fd2a5fb26de7",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -865,7 +932,10 @@
    "execution_count": 23,
    "id": "5bcf4056-963b-41e1-b963-6af2c09498b5",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -907,7 +977,10 @@
    "execution_count": 24,
    "id": "d4f822da-45bf-4222-95fa-5ce6a912869b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -954,14 +1027,11 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Bash with Marlowe Tools",
+   "display_name": "Bash",
    "language": "bash",
-   "name": "bash-minimal"
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": "shell",
-   "file_extension": ".sh",
-   "mimetype": "text/x-sh",
    "name": "bash"
   }
  },

--- a/01-runtime-cli/ReadMe.ipynb
+++ b/01-runtime-cli/ReadMe.ipynb
@@ -103,7 +103,10 @@
    "execution_count": 1,
    "id": "cd27279f-12aa-4d66-92a7-5eb1224b1d90",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -174,7 +177,10 @@
    "execution_count": 2,
    "id": "c7def6b8-c617-4049-872f-4974755d0cb0",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -204,7 +210,10 @@
    "execution_count": 3,
    "id": "111e60bf-a7c8-41f1-b729-15d1defd27df",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -234,7 +243,10 @@
    "execution_count": 4,
    "id": "d4eb8b9f-84a2-4fce-abec-8725dc67c46a",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -266,7 +278,10 @@
    "execution_count": 5,
    "id": "b60f9abe-4956-4783-86cf-1827bd076dfe",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -296,7 +311,10 @@
    "execution_count": 6,
    "id": "a4a8216e-c5d3-4706-8ab9-918252369263",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -326,7 +344,10 @@
    "execution_count": 7,
    "id": "3455b47d-45f9-4d31-aebe-ab0ea7b36aa9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -359,7 +380,11 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "4c959ebc-7c73-49ef-a1f9-a32771cc9ec9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -392,7 +417,11 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "aa229f08-6907-4f7b-b458-5fd18e0b9596",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -419,7 +448,11 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "30ec2929-27e1-4ae7-8ee0-82e710f15b6c",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -450,7 +483,11 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "2ac3ad1d-060f-4ff5-b055-c96011f724a0",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -480,7 +517,11 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "5b4b87af-265c-4d2c-bfe3-281614311fa8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "marlowe-cli template zcb \\\n",
@@ -508,7 +549,10 @@
    "execution_count": 13,
    "id": "36d8e09d-b426-4889-91f8-3a6842f9727b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -557,7 +601,11 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "112824a7-635f-4134-b133-a20e63660b35",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -646,7 +694,11 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "f2c5f0ad-8c56-486a-9107-8abfa61ab68f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "marlowe-cli run initialize \\\n",
@@ -668,7 +720,11 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "bb0789a1-3e56-4e5a-91aa-33417e957c9f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -753,7 +809,10 @@
    "execution_count": 17,
    "id": "87672246-de07-4356-8cee-3692eeb36572",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -833,7 +892,11 @@
    "cell_type": "code",
    "execution_count": 18,
    "id": "f8c85b72-afe2-460c-a48a-6e347ace520c",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -869,7 +932,11 @@
    "cell_type": "code",
    "execution_count": 19,
    "id": "43ddbc79-cc07-45e6-9266-aac7447b7fe3",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -904,7 +971,11 @@
    "cell_type": "code",
    "execution_count": 20,
    "id": "ae1f6a5f-b4f7-452f-9d1b-f0545135deb5",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -937,7 +1008,11 @@
    "cell_type": "code",
    "execution_count": 21,
    "id": "72115506-5bfd-480f-b3f0-47520dca84c1",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -963,7 +1038,11 @@
    "cell_type": "code",
    "execution_count": 22,
    "id": "c4af1000-9220-4f31-92e8-ee5eb405df0b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -993,7 +1072,11 @@
    "cell_type": "code",
    "execution_count": 23,
    "id": "a753938c-92bb-43aa-bb13-d09a112939c6",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1049,7 +1132,11 @@
    "cell_type": "code",
    "execution_count": 24,
    "id": "2ea93a41-ad4a-4040-842a-6c2eec4ba4ae",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1152,7 +1239,10 @@
    "execution_count": 25,
    "id": "bf42d7d0-be81-42a1-8da7-5ff07b9611ee",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1229,7 +1319,11 @@
    "cell_type": "code",
    "execution_count": 26,
    "id": "96e0b7b9-4816-46d3-ad2c-580dd7547b07",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1265,7 +1359,11 @@
    "cell_type": "code",
    "execution_count": 27,
    "id": "28c51136-8e5a-483b-891a-e9345f1a6be5",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1295,7 +1393,11 @@
    "cell_type": "code",
    "execution_count": 28,
    "id": "ab45188c-ab07-4918-96f2-79da42ab92f8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1343,7 +1445,11 @@
    "cell_type": "code",
    "execution_count": 29,
    "id": "bb1b0e65-3cf7-42e1-9495-ce45007e331a",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1372,7 +1478,11 @@
    "cell_type": "code",
    "execution_count": 30,
    "id": "bb813544-092a-4831-bff5-5ea7ce8a9259",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1398,7 +1508,11 @@
    "cell_type": "code",
    "execution_count": 31,
    "id": "b45dc15d-f54f-49cb-a36d-0524f47fd70e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1426,7 +1540,11 @@
    "cell_type": "code",
    "execution_count": 32,
    "id": "304baf28-2a07-4ca7-8576-c10c8a960fcd",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1455,7 +1573,11 @@
    "cell_type": "code",
    "execution_count": 33,
    "id": "6485d605-dec4-4bab-86f6-81bf002041ed",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1485,7 +1607,11 @@
    "cell_type": "code",
    "execution_count": 34,
    "id": "e0461725-7f2b-4256-ac83-8e681ecb3e35",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1562,7 +1688,11 @@
    "cell_type": "code",
    "execution_count": 35,
    "id": "d373efd1-9947-4ce9-837e-ba0796d89146",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1725,7 +1855,11 @@
    "cell_type": "code",
    "execution_count": 36,
    "id": "9756dcb3-a357-4b7d-b132-9c85105f0387",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1761,7 +1895,11 @@
    "cell_type": "code",
    "execution_count": 37,
    "id": "5fa86263-3fde-4995-be45-9625cbb35237",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1790,7 +1928,11 @@
    "cell_type": "code",
    "execution_count": 38,
    "id": "94e9f529-529b-4777-b829-dcab0a5fc3b8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1816,7 +1958,11 @@
    "cell_type": "code",
    "execution_count": 39,
    "id": "492de5e8-7f07-437c-9f88-80ccdf00636f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1845,7 +1991,11 @@
    "cell_type": "code",
    "execution_count": 40,
    "id": "3e8f27e3-e94a-4332-94a2-2f8af8800d56",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1884,7 +2034,11 @@
    "cell_type": "code",
    "execution_count": 41,
    "id": "14a0a55a-f0f4-40e7-9cc6-9bcc6600d7b1",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1969,7 +2123,11 @@
    "cell_type": "code",
    "execution_count": 42,
    "id": "bf25d4d4-ca3b-4d61-b4f9-546a44bbcddc",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2135,14 +2293,11 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Bash with Marlowe Tools",
+   "display_name": "Bash",
    "language": "bash",
-   "name": "bash-minimal"
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": "shell",
-   "file_extension": ".sh",
-   "mimetype": "text/x-sh",
    "name": "bash"
   }
  },

--- a/02-runtime-rest/ReadMe.ipynb
+++ b/02-runtime-rest/ReadMe.ipynb
@@ -101,7 +101,10 @@
    "execution_count": 60,
    "id": "e1859d35-ded3-4e16-be43-b1ef030d7f16",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -176,7 +179,10 @@
    "execution_count": 61,
    "id": "38d0bad1-3b9e-4d80-9aec-a4357c8dc79a",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -206,7 +212,10 @@
    "execution_count": 62,
    "id": "a16fd543-cabf-4540-879c-ed0594ca5ff1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -236,7 +245,10 @@
    "execution_count": 63,
    "id": "b1d78493-a1a1-4739-b911-02b901c73bda",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -268,7 +280,10 @@
    "execution_count": 64,
    "id": "5103b793-05a7-4a9c-bb5b-ed250bcbcc1e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -298,7 +313,10 @@
    "execution_count": 65,
    "id": "3af7a962-3038-4b55-a31a-cd7ade94b5ec",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -328,7 +346,10 @@
    "execution_count": 66,
    "id": "3455b47d-45f9-4d31-aebe-ab0ea7b36aa9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -359,7 +380,11 @@
    "cell_type": "code",
    "execution_count": 67,
    "id": "8d28fcbc-c73f-4c27-8d68-069d8ebe98ce",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -390,7 +415,11 @@
    "cell_type": "code",
    "execution_count": 68,
    "id": "8f699238-b0a0-4626-b04f-e93d93b0f458",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -418,7 +447,10 @@
    "execution_count": 69,
    "id": "d06a9229-9e53-4a00-accf-ae06b115ff39",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -465,7 +497,11 @@
    "cell_type": "code",
    "execution_count": 70,
    "id": "327df025-16bf-4f69-acfc-02e3ce56e795",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -492,7 +528,11 @@
    "cell_type": "code",
    "execution_count": 71,
    "id": "f1797871-350b-400b-b12f-5bc877efca94",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -522,7 +562,11 @@
    "cell_type": "code",
    "execution_count": 72,
    "id": "3301ffcf-635e-4c31-bbc9-38189a6fb3c8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "marlowe-cli template zcb \\\n",
@@ -550,7 +594,10 @@
    "execution_count": 73,
    "id": "4b7754a1-3e13-4d54-81a3-9b98be4c87c9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -599,7 +646,11 @@
    "cell_type": "code",
    "execution_count": 74,
    "id": "bf449c31-b594-4d80-811e-80cc0b8db14a",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -706,7 +757,11 @@
    "cell_type": "code",
    "execution_count": 75,
    "id": "69abcbb8-6a8e-470b-9dd3-365f15c1f04b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -742,7 +797,11 @@
    "cell_type": "code",
    "execution_count": 76,
    "id": "d88f4f44-49a1-4548-ac97-6fe95fb6059b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -782,7 +841,11 @@
    "cell_type": "code",
    "execution_count": 77,
    "id": "f446b742-efe7-49bc-96a0-49b4b604bd9b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -809,7 +872,11 @@
    "cell_type": "code",
    "execution_count": 78,
    "id": "18b60f01-ae10-415d-96bf-9dba0070b752",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-1.json > tx-1.unsigned"
@@ -834,7 +901,11 @@
    "cell_type": "code",
    "execution_count": 79,
    "id": "500d6e54-6f2a-478a-a715-5149ebe057a2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -867,7 +938,11 @@
    "cell_type": "code",
    "execution_count": 80,
    "id": "72115506-5bfd-480f-b3f0-47520dca84c1",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -893,7 +968,11 @@
    "cell_type": "code",
    "execution_count": 81,
    "id": "6413cea3-50cc-4537-a8ed-707f4d6b2ba9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -922,7 +1001,10 @@
    "execution_count": 82,
    "id": "dc8bc919-7114-46fe-93b3-b32802667636",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -945,7 +1027,10 @@
    "execution_count": 83,
    "id": "8aebb77c-2cfd-4d62-8a2f-0fea8a61a7af",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -977,7 +1062,11 @@
    "cell_type": "code",
    "execution_count": 84,
    "id": "8328b458-43fb-4e53-8060-1740d25cf93b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -996,7 +1085,11 @@
    "cell_type": "code",
    "execution_count": 85,
    "id": "e805f893-bcd8-4169-a2da-90f1cfa080b2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1153,7 +1246,10 @@
    "execution_count": 86,
    "id": "1fbf5b90-ba80-44b9-83f5-791a7a10b2ab",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1185,7 +1281,11 @@
    "cell_type": "code",
    "execution_count": 87,
    "id": "3c8a6076-f342-489c-939c-e9c017b6b445",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1223,7 +1323,11 @@
    "cell_type": "code",
    "execution_count": 88,
    "id": "4fc16b02-358c-438f-9e5b-7d709da7eac5",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1255,7 +1359,11 @@
    "cell_type": "code",
    "execution_count": 89,
    "id": "465152a1-eaaa-4dab-9035-aa306c0022fa",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1296,7 +1404,11 @@
    "cell_type": "code",
    "execution_count": 90,
    "id": "6fb5d4c0-c158-434b-8dac-b2160f426e01",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-2.json > tx-2.unsigned"
@@ -1306,7 +1418,11 @@
    "cell_type": "code",
    "execution_count": 91,
    "id": "b2aa2f81-d6b7-4994-b90b-0812d5fb3fca",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1339,7 +1455,11 @@
    "cell_type": "code",
    "execution_count": 92,
    "id": "9b994073-d1b9-44a4-8149-9b307a69a4e4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1365,7 +1485,11 @@
    "cell_type": "code",
    "execution_count": 93,
    "id": "b45dc15d-f54f-49cb-a36d-0524f47fd70e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1394,7 +1518,11 @@
    "cell_type": "code",
    "execution_count": 94,
    "id": "6485d605-dec4-4bab-86f6-81bf002041ed",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1422,7 +1550,11 @@
    "cell_type": "code",
    "execution_count": 95,
    "id": "82e3a33e-7ce1-4aa3-824c-59cbfe881ba9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1452,7 +1584,11 @@
    "cell_type": "code",
    "execution_count": 96,
    "id": "e0461725-7f2b-4256-ac83-8e681ecb3e35",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1544,7 +1680,10 @@
    "execution_count": 97,
    "id": "87bf77eb-ba6f-4981-b7a6-453c63685a76",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1575,7 +1714,11 @@
    "cell_type": "code",
    "execution_count": 98,
    "id": "42a6ba19-7618-417f-a9f2-9c4380a67c8b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1615,7 +1758,11 @@
    "cell_type": "code",
    "execution_count": 99,
    "id": "c4858e39-8eb6-4407-bf68-985938162a74",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-3.json > tx-3.unsigned"
@@ -1625,7 +1772,11 @@
    "cell_type": "code",
    "execution_count": 100,
    "id": "a1e8ffa6-1a77-422b-8df3-aeeb78716942",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1658,7 +1809,11 @@
    "cell_type": "code",
    "execution_count": 101,
    "id": "b3df594b-eb21-4551-8c84-26eef2af54fd",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1684,7 +1839,11 @@
    "cell_type": "code",
    "execution_count": 102,
    "id": "0c876c3c-381c-441d-92e9-b6bedbaf23a9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1719,7 +1878,11 @@
    "cell_type": "code",
    "execution_count": 103,
    "id": "1eb38d8c-4e20-4172-9deb-4364680823db",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1757,7 +1920,11 @@
    "cell_type": "code",
    "execution_count": 104,
    "id": "9e0e83d1-cd70-4c42-a350-242e0b5fdd06",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1789,7 +1956,11 @@
    "cell_type": "code",
    "execution_count": 105,
    "id": "dc569d98-d5a0-4c40-bafb-6018ce4084ed",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1830,7 +2001,11 @@
    "cell_type": "code",
    "execution_count": 106,
    "id": "b6f04318-bfb8-47d5-b681-0abb90d62640",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-4.json > tx-4.unsigned"
@@ -1840,7 +2015,11 @@
    "cell_type": "code",
    "execution_count": 107,
    "id": "0faa8cd4-902d-4399-8621-03dac811deda",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1873,7 +2052,11 @@
    "cell_type": "code",
    "execution_count": 108,
    "id": "53279d7a-c775-422e-a258-e4077df1e2b4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1899,7 +2082,11 @@
    "cell_type": "code",
    "execution_count": 109,
    "id": "3e8f27e3-e94a-4332-94a2-2f8af8800d56",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1928,7 +2115,11 @@
    "cell_type": "code",
    "execution_count": 110,
    "id": "6d7bd817-4174-42c1-bc15-29e00f05645b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1966,7 +2157,11 @@
    "cell_type": "code",
    "execution_count": 111,
    "id": "f6f164ae-2fca-4e9f-9368-d2ffe8ce83b9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2024,7 +2219,10 @@
    "execution_count": 112,
    "id": "6c1cabad-cde9-4086-bc9b-6bc33fe4fba3",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -2055,7 +2253,11 @@
    "cell_type": "code",
    "execution_count": 113,
    "id": "0a07552a-52db-4d24-a757-c2e93aec456b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2095,7 +2297,11 @@
    "cell_type": "code",
    "execution_count": 114,
    "id": "aa048a7f-6619-4e12-9cf1-98791744b430",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-5.json > tx-5.unsigned"
@@ -2105,7 +2311,11 @@
    "cell_type": "code",
    "execution_count": 115,
    "id": "a0ac6dc2-1ffd-43f8-991e-c6108b100606",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2138,7 +2348,11 @@
    "cell_type": "code",
    "execution_count": 116,
    "id": "0465596a-9141-476b-84e2-003f2c55eefa",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2164,7 +2378,11 @@
    "cell_type": "code",
    "execution_count": 117,
    "id": "98ac7654-f649-42dd-972f-103c3b55ad4f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2196,7 +2414,11 @@
    "cell_type": "code",
    "execution_count": 118,
    "id": "9f2104c6-6463-4ce5-a1b9-e86e066a08ce",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3659,14 +3881,11 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Bash with Marlowe Tools",
+   "display_name": "Bash",
    "language": "bash",
-   "name": "bash-minimal"
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": "shell",
-   "file_extension": ".sh",
-   "mimetype": "text/x-sh",
    "name": "bash"
   }
  },

--- a/03-marlowe-cli/ReadMe.ipynb
+++ b/03-marlowe-cli/ReadMe.ipynb
@@ -101,7 +101,10 @@
    "execution_count": 1,
    "id": "cd27279f-12aa-4d66-92a7-5eb1224b1d90",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -164,7 +167,10 @@
    "execution_count": 2,
    "id": "c7def6b8-c617-4049-872f-4974755d0cb0",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -194,7 +200,10 @@
    "execution_count": 3,
    "id": "111e60bf-a7c8-41f1-b729-15d1defd27df",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -224,7 +233,10 @@
    "execution_count": 4,
    "id": "d4eb8b9f-84a2-4fce-abec-8725dc67c46a",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -256,7 +268,10 @@
    "execution_count": 5,
    "id": "b60f9abe-4956-4783-86cf-1827bd076dfe",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -286,7 +301,10 @@
    "execution_count": 6,
    "id": "a4a8216e-c5d3-4706-8ab9-918252369263",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -316,7 +334,10 @@
    "execution_count": 7,
    "id": "3455b47d-45f9-4d31-aebe-ab0ea7b36aa9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -349,7 +370,11 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "4c959ebc-7c73-49ef-a1f9-a32771cc9ec9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -382,7 +407,11 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "aa229f08-6907-4f7b-b458-5fd18e0b9596",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -409,7 +438,11 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "30ec2929-27e1-4ae7-8ee0-82e710f15b6c",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -440,7 +473,11 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "2ac3ad1d-060f-4ff5-b055-c96011f724a0",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -470,7 +507,11 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "5b4b87af-265c-4d2c-bfe3-281614311fa8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "marlowe-cli template zcb \\\n",
@@ -498,7 +539,10 @@
    "execution_count": 13,
    "id": "36d8e09d-b426-4889-91f8-3a6842f9727b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -547,7 +591,11 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "112824a7-635f-4134-b133-a20e63660b35",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -653,7 +701,10 @@
    "execution_count": 17,
    "id": "87672246-de07-4356-8cee-3692eeb36572",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -713,7 +764,10 @@
    "execution_count": 18,
    "id": "2053db7a-3244-4d30-a9e9-f5f1eb28ab45",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -737,7 +791,10 @@
    "execution_count": 19,
    "id": "06807391-74dc-49e1-b110-df167f88bb3b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -793,7 +850,10 @@
    "execution_count": 20,
    "id": "c856072c-e31a-4363-8291-ef96292caedc",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -836,7 +896,11 @@
    "cell_type": "code",
    "execution_count": 21,
    "id": "72115506-5bfd-480f-b3f0-47520dca84c1",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -862,7 +926,11 @@
    "cell_type": "code",
    "execution_count": 22,
    "id": "c4af1000-9220-4f31-92e8-ee5eb405df0b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -893,7 +961,10 @@
    "execution_count": 23,
    "id": "bf42d7d0-be81-42a1-8da7-5ff07b9611ee",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -943,7 +1014,10 @@
    "execution_count": 24,
    "id": "d2fac183-6fbd-4d0a-80a4-6045a20a8f2d",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -983,7 +1057,10 @@
    "execution_count": 25,
    "id": "2e821767-d465-4051-96b6-f1128ec9cffc",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1028,7 +1105,11 @@
    "cell_type": "code",
    "execution_count": 26,
    "id": "bb813544-092a-4831-bff5-5ea7ce8a9259",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1054,7 +1135,11 @@
    "cell_type": "code",
    "execution_count": 27,
    "id": "b45dc15d-f54f-49cb-a36d-0524f47fd70e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1082,7 +1167,11 @@
    "cell_type": "code",
    "execution_count": 28,
    "id": "304baf28-2a07-4ca7-8576-c10c8a960fcd",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1111,7 +1200,11 @@
    "cell_type": "code",
    "execution_count": 29,
    "id": "6485d605-dec4-4bab-86f6-81bf002041ed",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1142,7 +1235,10 @@
    "execution_count": 30,
    "id": "10a49a12-18b5-4240-9d95-6bad4e82375d",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1186,7 +1282,10 @@
    "execution_count": 31,
    "id": "7c405029-bf87-4eac-8b9e-630f64ddd53e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1231,7 +1330,11 @@
    "cell_type": "code",
    "execution_count": 32,
    "id": "94e9f529-529b-4777-b829-dcab0a5fc3b8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1257,7 +1360,11 @@
    "cell_type": "code",
    "execution_count": 33,
    "id": "492de5e8-7f07-437c-9f88-80ccdf00636f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1286,7 +1393,11 @@
    "cell_type": "code",
    "execution_count": 34,
    "id": "3e8f27e3-e94a-4332-94a2-2f8af8800d56",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1314,14 +1425,11 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Bash with Marlowe Tools",
+   "display_name": "Bash",
    "language": "bash",
-   "name": "bash-minimal"
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": "shell",
-   "file_extension": ".sh",
-   "mimetype": "text/x-sh",
    "name": "bash"
   }
  },

--- a/04-escrow-rest/ReadMe.ipynb
+++ b/04-escrow-rest/ReadMe.ipynb
@@ -115,7 +115,10 @@
    "execution_count": 1,
    "id": "e1859d35-ded3-4e16-be43-b1ef030d7f16",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -190,7 +193,10 @@
    "execution_count": 2,
    "id": "38d0bad1-3b9e-4d80-9aec-a4357c8dc79a",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -220,7 +226,10 @@
    "execution_count": 3,
    "id": "a16fd543-cabf-4540-879c-ed0594ca5ff1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -250,7 +259,10 @@
    "execution_count": 4,
    "id": "b1d78493-a1a1-4739-b911-02b901c73bda",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -282,7 +294,10 @@
    "execution_count": 5,
    "id": "5103b793-05a7-4a9c-bb5b-ed250bcbcc1e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -312,7 +327,10 @@
    "execution_count": 6,
    "id": "3af7a962-3038-4b55-a31a-cd7ade94b5ec",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -342,7 +360,10 @@
    "execution_count": 7,
    "id": "3455b47d-45f9-4d31-aebe-ab0ea7b36aa9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -374,7 +395,10 @@
    "execution_count": 8,
    "id": "4f9e1680-77da-43f9-9495-14d8a8a9929b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -404,7 +428,10 @@
    "execution_count": 9,
    "id": "ca1d52a9-8499-4ccc-ab2a-ff9aed202944",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -434,7 +461,10 @@
    "execution_count": 10,
    "id": "d9d17190-eed0-456f-8aa0-6f0a2b4d83dc",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -465,7 +495,11 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "8d28fcbc-c73f-4c27-8d68-069d8ebe98ce",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -493,7 +527,11 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "8f699238-b0a0-4626-b04f-e93d93b0f458",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -521,7 +559,10 @@
    "execution_count": 13,
    "id": "d06a9229-9e53-4a00-accf-ae06b115ff39",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -569,7 +610,11 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "327df025-16bf-4f69-acfc-02e3ce56e795",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -596,7 +641,11 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "f1797871-350b-400b-b12f-5bc877efca94",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -634,7 +683,10 @@
    "execution_count": 16,
    "id": "efec81d2-4cd2-4b72-8fab-82a6e60741c7",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -665,7 +717,10 @@
    "execution_count": 17,
    "id": "4b7754a1-3e13-4d54-81a3-9b98be4c87c9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -721,7 +776,11 @@
    "cell_type": "code",
    "execution_count": 18,
    "id": "58855a22-decd-4730-bac7-800d0f766034",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -868,7 +927,11 @@
    "cell_type": "code",
    "execution_count": 19,
    "id": "4314ece0-462f-4df8-b739-f9db58cbc6a9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -905,7 +968,11 @@
    "cell_type": "code",
    "execution_count": 20,
    "id": "5843b85f-f87e-46d2-a6e8-2550328bb6c6",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -945,7 +1012,11 @@
    "cell_type": "code",
    "execution_count": 21,
    "id": "2e882a2e-07a0-4bf7-891d-cf99651c8c5a",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -972,7 +1043,11 @@
    "cell_type": "code",
    "execution_count": 22,
    "id": "fb237371-071c-4b70-baca-c67f0751ac3e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-1.json > tx-1.unsigned"
@@ -997,7 +1072,11 @@
    "cell_type": "code",
    "execution_count": 23,
    "id": "89bb49ae-2353-4d85-9ae5-ad805061f2cd",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1030,7 +1109,11 @@
    "cell_type": "code",
    "execution_count": 24,
    "id": "006ca411-2088-439f-b735-b49892de22e8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1056,7 +1139,11 @@
    "cell_type": "code",
    "execution_count": 25,
    "id": "bc7b2078-d23c-47f4-9f12-697de8469ce1",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1085,7 +1172,10 @@
    "execution_count": 26,
    "id": "613f0751-3bc5-4ca7-b208-ef5830eef61d",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1108,7 +1198,10 @@
    "execution_count": 27,
    "id": "7f6d2b5e-86c2-4f53-ba20-8f95b43c3145",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1131,7 +1224,10 @@
    "execution_count": 28,
    "id": "cbfab192-5a28-4595-b3ef-aa8bfdcee154",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1163,7 +1259,11 @@
    "cell_type": "code",
    "execution_count": 29,
    "id": "8328b458-43fb-4e53-8060-1740d25cf93b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1182,7 +1282,11 @@
    "cell_type": "code",
    "execution_count": 30,
    "id": "e805f893-bcd8-4169-a2da-90f1cfa080b2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1431,7 +1535,10 @@
    "execution_count": 31,
    "id": "1fbf5b90-ba80-44b9-83f5-791a7a10b2ab",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1463,7 +1570,11 @@
    "cell_type": "code",
    "execution_count": 32,
    "id": "3c8a6076-f342-489c-939c-e9c017b6b445",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1493,7 +1604,11 @@
    "cell_type": "code",
    "execution_count": 33,
    "id": "4fc16b02-358c-438f-9e5b-7d709da7eac5",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1525,7 +1640,11 @@
    "cell_type": "code",
    "execution_count": 34,
    "id": "465152a1-eaaa-4dab-9035-aa306c0022fa",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1566,7 +1685,11 @@
    "cell_type": "code",
    "execution_count": 35,
    "id": "6fb5d4c0-c158-434b-8dac-b2160f426e01",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-2.json > tx-2.unsigned"
@@ -1576,7 +1699,11 @@
    "cell_type": "code",
    "execution_count": 36,
    "id": "b2aa2f81-d6b7-4994-b90b-0812d5fb3fca",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1609,7 +1736,11 @@
    "cell_type": "code",
    "execution_count": 37,
    "id": "9b994073-d1b9-44a4-8149-9b307a69a4e4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1635,7 +1766,11 @@
    "cell_type": "code",
    "execution_count": 38,
    "id": "b45dc15d-f54f-49cb-a36d-0524f47fd70e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1664,7 +1799,11 @@
    "cell_type": "code",
    "execution_count": 39,
    "id": "6485d605-dec4-4bab-86f6-81bf002041ed",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1694,7 +1833,11 @@
    "cell_type": "code",
    "execution_count": 40,
    "id": "e0461725-7f2b-4256-ac83-8e681ecb3e35",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1848,7 +1991,10 @@
    "execution_count": 41,
    "id": "b8a4045e-ceca-4272-90dc-72747e5329ab",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1878,7 +2024,10 @@
    "execution_count": 42,
    "id": "42aeee88-13e1-4170-b18a-727cd5cde877",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1906,7 +2055,11 @@
    "cell_type": "code",
    "execution_count": 43,
    "id": "3fee1c9b-c4d9-4ab4-9b47-061db363d31f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1938,7 +2091,11 @@
    "cell_type": "code",
    "execution_count": 44,
    "id": "387362e6-8cb8-4a46-9222-4a065d964167",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1979,7 +2136,11 @@
    "cell_type": "code",
    "execution_count": 45,
    "id": "57490822-4650-481c-b2a3-beb73075ae6b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-3.json > tx-3.unsigned"
@@ -1989,7 +2150,11 @@
    "cell_type": "code",
    "execution_count": 46,
    "id": "61733dd3-cac6-4ef3-bee8-9cb7ec4362ff",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2022,7 +2187,11 @@
    "cell_type": "code",
    "execution_count": 47,
    "id": "b7424735-4fba-433d-99ee-ae9b5ec91ab2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2048,7 +2217,11 @@
    "cell_type": "code",
    "execution_count": 48,
    "id": "1f831ae4-36e9-4fb6-9c7b-c6a19e6f249f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2077,7 +2250,11 @@
    "cell_type": "code",
    "execution_count": 49,
    "id": "0020850f-5700-4a2e-a1b6-f3486ab9eb14",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2107,7 +2284,11 @@
    "cell_type": "code",
    "execution_count": 50,
    "id": "b91dc7ca-2cf8-4d8d-81a7-3d0880aafd90",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2230,7 +2411,10 @@
    "execution_count": 51,
    "id": "f726d751-dee2-46e3-8d95-066fbb3c4a8f",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -2258,7 +2442,11 @@
    "cell_type": "code",
    "execution_count": 52,
    "id": "10fe530d-ba44-4ef8-bc8f-a4fa9f301c1f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2290,7 +2478,11 @@
    "cell_type": "code",
    "execution_count": 53,
    "id": "f430a724-b919-432b-a06d-1d179a746f7d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2331,7 +2523,11 @@
    "cell_type": "code",
    "execution_count": 54,
    "id": "b6a98bfc-6ffd-4d4b-97a0-89e380f23f15",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-4.json > tx-4.unsigned"
@@ -2341,7 +2537,11 @@
    "cell_type": "code",
    "execution_count": 55,
    "id": "01de4b62-c225-4675-8945-97292798286b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2374,7 +2574,11 @@
    "cell_type": "code",
    "execution_count": 56,
    "id": "3bc43634-af98-43a7-bcd1-0d2bc8ab6a88",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2400,7 +2604,11 @@
    "cell_type": "code",
    "execution_count": 57,
    "id": "99a542df-cd08-4cc3-b835-24498d673969",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2429,7 +2637,11 @@
    "cell_type": "code",
    "execution_count": 58,
    "id": "4d076dc7-1768-4a3d-b11f-61ed2c5f1318",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2459,7 +2671,11 @@
    "cell_type": "code",
    "execution_count": 59,
    "id": "92f51247-9285-45a4-93b9-1d561425a4cf",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2565,7 +2781,10 @@
    "execution_count": 60,
    "id": "3b6ea2d9-22f3-4cf8-a6c2-f4f4acadad70",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -2593,7 +2812,11 @@
    "cell_type": "code",
    "execution_count": 61,
    "id": "91be787b-0a96-4ea9-8f50-e942abb381b8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2625,7 +2848,11 @@
    "cell_type": "code",
    "execution_count": 62,
    "id": "e5d6e036-aa13-4b93-9d9d-499787d05341",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2666,7 +2893,11 @@
    "cell_type": "code",
    "execution_count": 63,
    "id": "6f48a296-9751-4496-9d4b-e9278104b437",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-5.json > tx-5.unsigned"
@@ -2676,7 +2907,11 @@
    "cell_type": "code",
    "execution_count": 64,
    "id": "6c725733-bc6a-4903-a5cd-60766b258a40",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2709,7 +2944,11 @@
    "cell_type": "code",
    "execution_count": 65,
    "id": "05eaf50a-f7c9-4af8-9bd1-fdc72c6e3cd2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2735,7 +2974,11 @@
    "cell_type": "code",
    "execution_count": 66,
    "id": "ee3f2e7f-0268-4c4a-84fe-bfc5ca2cf297",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2765,7 +3008,11 @@
    "cell_type": "code",
    "execution_count": 67,
    "id": "de0b22dd-6563-4376-a9f7-fda2dd58939f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2795,7 +3042,11 @@
    "cell_type": "code",
    "execution_count": 68,
    "id": "6c5841e6-f94b-4f62-9a9e-efab8b427aa2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2850,7 +3101,10 @@
    "execution_count": 69,
    "id": "223cd7b7-30d5-4e7d-b99d-76a5926ff737",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -2881,7 +3135,11 @@
    "cell_type": "code",
    "execution_count": 70,
    "id": "fae22f06-a0b5-4366-88c1-4926948dfb50",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2921,7 +3179,11 @@
    "cell_type": "code",
    "execution_count": 71,
    "id": "e5d6f45f-89cf-402b-8a17-520a85d9f757",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-6.json > tx-6.unsigned"
@@ -2931,7 +3193,11 @@
    "cell_type": "code",
    "execution_count": 72,
    "id": "c7fa907d-07d8-46b2-9ece-a6f52320e628",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2964,7 +3230,11 @@
    "cell_type": "code",
    "execution_count": 73,
    "id": "331d652b-e7fa-4eb0-96a3-e5cfa565b1b9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2990,7 +3260,11 @@
    "cell_type": "code",
    "execution_count": 74,
    "id": "18fabe44-1bd2-40ba-8764-f0b384fb5739",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3021,7 +3295,11 @@
    "cell_type": "code",
    "execution_count": 75,
    "id": "72ca3c23-4074-4581-ac08-30f46fca17b4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3048,14 +3326,11 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Bash with Marlowe Tools",
+   "display_name": "Bash",
    "language": "bash",
-   "name": "bash-minimal"
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": "shell",
-   "file_extension": ".sh",
-   "mimetype": "text/x-sh",
    "name": "bash"
   }
  },

--- a/05-swap-rest/ReadMe.ipynb
+++ b/05-swap-rest/ReadMe.ipynb
@@ -101,7 +101,10 @@
    "execution_count": 1,
    "id": "e1859d35-ded3-4e16-be43-b1ef030d7f16",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -176,7 +179,10 @@
    "execution_count": 2,
    "id": "38d0bad1-3b9e-4d80-9aec-a4357c8dc79a",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -206,7 +212,10 @@
    "execution_count": 3,
    "id": "a16fd543-cabf-4540-879c-ed0594ca5ff1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -236,7 +245,10 @@
    "execution_count": 4,
    "id": "b1d78493-a1a1-4739-b911-02b901c73bda",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -268,7 +280,10 @@
    "execution_count": 5,
    "id": "5103b793-05a7-4a9c-bb5b-ed250bcbcc1e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -298,7 +313,10 @@
    "execution_count": 6,
    "id": "3af7a962-3038-4b55-a31a-cd7ade94b5ec",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -329,7 +347,10 @@
    "execution_count": 7,
    "id": "3455b47d-45f9-4d31-aebe-ab0ea7b36aa9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -360,7 +381,11 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "8d28fcbc-c73f-4c27-8d68-069d8ebe98ce",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -391,7 +416,11 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "8f699238-b0a0-4626-b04f-e93d93b0f458",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -419,7 +448,10 @@
    "execution_count": 10,
    "id": "d06a9229-9e53-4a00-accf-ae06b115ff39",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [],
    "source": [
@@ -463,7 +495,11 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "58855a22-decd-4730-bac7-800d0f766034",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -564,7 +600,11 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "4314ece0-462f-4df8-b739-f9db58cbc6a9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -600,7 +640,11 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "5843b85f-f87e-46d2-a6e8-2550328bb6c6",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -640,7 +684,11 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "2e882a2e-07a0-4bf7-891d-cf99651c8c5a",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -667,7 +715,11 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "fb237371-071c-4b70-baca-c67f0751ac3e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-1.json > tx-1.unsigned"
@@ -692,7 +744,11 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "89bb49ae-2353-4d85-9ae5-ad805061f2cd",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -725,7 +781,11 @@
    "cell_type": "code",
    "execution_count": 17,
    "id": "006ca411-2088-439f-b735-b49892de22e8",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -751,7 +811,11 @@
    "cell_type": "code",
    "execution_count": 18,
    "id": "bc7b2078-d23c-47f4-9f12-697de8469ce1",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -780,7 +844,10 @@
    "execution_count": 19,
    "id": "613f0751-3bc5-4ca7-b208-ef5830eef61d",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -803,7 +870,10 @@
    "execution_count": 20,
    "id": "7f6d2b5e-86c2-4f53-ba20-8f95b43c3145",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -836,7 +906,11 @@
    "cell_type": "code",
    "execution_count": 21,
    "id": "8328b458-43fb-4e53-8060-1740d25cf93b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -855,7 +929,11 @@
    "cell_type": "code",
    "execution_count": 22,
    "id": "e805f893-bcd8-4169-a2da-90f1cfa080b2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1011,7 +1089,11 @@
    "cell_type": "code",
    "execution_count": 23,
    "id": "3c8a6076-f342-489c-939c-e9c017b6b445",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1041,7 +1123,11 @@
    "cell_type": "code",
    "execution_count": 24,
    "id": "4fc16b02-358c-438f-9e5b-7d709da7eac5",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1073,7 +1159,11 @@
    "cell_type": "code",
    "execution_count": 25,
    "id": "465152a1-eaaa-4dab-9035-aa306c0022fa",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1114,7 +1204,11 @@
    "cell_type": "code",
    "execution_count": 26,
    "id": "6fb5d4c0-c158-434b-8dac-b2160f426e01",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-2.json > tx-2.unsigned"
@@ -1124,7 +1218,11 @@
    "cell_type": "code",
    "execution_count": 27,
    "id": "b2aa2f81-d6b7-4994-b90b-0812d5fb3fca",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1157,7 +1255,11 @@
    "cell_type": "code",
    "execution_count": 28,
    "id": "9b994073-d1b9-44a4-8149-9b307a69a4e4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1183,7 +1285,11 @@
    "cell_type": "code",
    "execution_count": 29,
    "id": "b45dc15d-f54f-49cb-a36d-0524f47fd70e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1212,7 +1318,11 @@
    "cell_type": "code",
    "execution_count": 30,
    "id": "6485d605-dec4-4bab-86f6-81bf002041ed",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1242,7 +1352,11 @@
    "cell_type": "code",
    "execution_count": 31,
    "id": "e0461725-7f2b-4256-ac83-8e681ecb3e35",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1348,7 +1462,10 @@
    "execution_count": 32,
    "id": "42aeee88-13e1-4170-b18a-727cd5cde877",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1380,7 +1497,11 @@
    "cell_type": "code",
    "execution_count": 33,
    "id": "3fee1c9b-c4d9-4ab4-9b47-061db363d31f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1412,7 +1533,11 @@
    "cell_type": "code",
    "execution_count": 34,
    "id": "387362e6-8cb8-4a46-9222-4a065d964167",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1453,7 +1578,11 @@
    "cell_type": "code",
    "execution_count": 35,
    "id": "57490822-4650-481c-b2a3-beb73075ae6b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-3.json > tx-3.unsigned"
@@ -1463,7 +1592,11 @@
    "cell_type": "code",
    "execution_count": 36,
    "id": "61733dd3-cac6-4ef3-bee8-9cb7ec4362ff",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1496,7 +1629,11 @@
    "cell_type": "code",
    "execution_count": 37,
    "id": "b7424735-4fba-433d-99ee-ae9b5ec91ab2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1522,7 +1659,11 @@
    "cell_type": "code",
    "execution_count": 38,
    "id": "1f831ae4-36e9-4fb6-9c7b-c6a19e6f249f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1551,7 +1692,11 @@
    "cell_type": "code",
    "execution_count": 39,
    "id": "0020850f-5700-4a2e-a1b6-f3486ab9eb14",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1579,7 +1724,11 @@
    "cell_type": "code",
    "execution_count": 40,
    "id": "059097db-7be5-4c14-841b-8f208e915413",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1609,7 +1758,11 @@
    "cell_type": "code",
    "execution_count": 41,
    "id": "b91dc7ca-2cf8-4d8d-81a7-3d0880aafd90",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1667,7 +1820,10 @@
    "execution_count": 42,
    "id": "223cd7b7-30d5-4e7d-b99d-76a5926ff737",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1698,7 +1854,11 @@
    "cell_type": "code",
    "execution_count": 43,
    "id": "fae22f06-a0b5-4366-88c1-4926948dfb50",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1738,7 +1898,11 @@
    "cell_type": "code",
    "execution_count": 44,
    "id": "e5d6f45f-89cf-402b-8a17-520a85d9f757",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-4.json > tx-4.unsigned"
@@ -1748,7 +1912,11 @@
    "cell_type": "code",
    "execution_count": 45,
    "id": "c7fa907d-07d8-46b2-9ece-a6f52320e628",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1781,7 +1949,11 @@
    "cell_type": "code",
    "execution_count": 46,
    "id": "331d652b-e7fa-4eb0-96a3-e5cfa565b1b9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1807,7 +1979,11 @@
    "cell_type": "code",
    "execution_count": 47,
    "id": "18fabe44-1bd2-40ba-8764-f0b384fb5739",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1840,7 +2016,11 @@
    "cell_type": "code",
    "execution_count": 48,
    "id": "72ca3c23-4074-4581-ac08-30f46fca17b4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1879,7 +2059,10 @@
    "execution_count": 49,
    "id": "be3d3614-94a4-4ebc-af0c-b87b12180baf",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "shellscript"
+    }
    },
    "outputs": [
     {
@@ -1910,7 +2093,11 @@
    "cell_type": "code",
    "execution_count": 50,
    "id": "a4e151cb-0df7-4d70-a6b3-09da7066601a",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1950,7 +2137,11 @@
    "cell_type": "code",
    "execution_count": 51,
    "id": "476ccaa4-2da7-4f83-8bda-085f4574a6f7",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
     "jq '.resource.txBody' response-5.json > tx-5.unsigned"
@@ -1960,7 +2151,11 @@
    "cell_type": "code",
    "execution_count": 52,
    "id": "a40b3d0d-01d4-4c08-998f-5649446fc7fe",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1993,7 +2188,11 @@
    "cell_type": "code",
    "execution_count": 53,
    "id": "55f05104-8def-4817-b68a-5da197d131d0",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2019,7 +2218,11 @@
    "cell_type": "code",
    "execution_count": 54,
    "id": "daa35baf-eade-49c5-8d3f-d204f31a5600",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2050,7 +2253,11 @@
    "cell_type": "code",
    "execution_count": 55,
    "id": "6fda49c9-f5f1-4cc9-95aa-7ab9a9df2b12",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2077,14 +2284,11 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Bash with Marlowe Tools",
+   "display_name": "Bash",
    "language": "bash",
-   "name": "bash-minimal"
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": "shell",
-   "file_extension": ".sh",
-   "mimetype": "text/x-sh",
    "name": "bash"
   }
  },


### PR DESCRIPTION
Updated notebooks to work out of the box with Demeter workspaces.

1. Set the correct `kernelspec` to `Bash` on each notebook.
2. Added vscode metadata.