### PR TITLE
PLT-5393 add a note to recover from corrupt postgres affecting marlow…

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -213,6 +213,14 @@ docker exec -it marlowe-starter-kit_postgres_1 psql -U postgres chain_preprod -c
 (1 row)
 ```
 
+Note: If the `marlowe-indexer` query result is not greater than or equal to `25627611`, you may need to reset the docker postgres volume:
+
+```bash
+docker compose stop postgres
+docker compose remove postgres
+docker volume rm marlowe-starter-kit_postgres
+docker compose up -d
+```
 
 ### Marlowe Runtime Proxy Service
 


### PR DESCRIPTION
Adding a note on how to reset docker postgres database incases where marlowe indexer was not populated correctly.