### PR TITLE
Correct link to REST API docs page for Update 02-runtime-rest.ipynb

### DIFF
--- a/02-runtime-rest.ipynb
+++ b/02-runtime-rest.ipynb
@@ -2484,7 +2484,7 @@
    "id": "eb6f2357-705e-4aa9-bd54-9164830add53",
    "metadata": {},
    "source": [
-    "It is also available at https://marlowe.iohk.io/docs/development/runtime-rest-api/.\n",
+    "It is also available at https://docs.marlowe.iohk.io/api/get-contracts.\n",
     "\n",
     "![Marlowe Runtime OpenAPI](images/openapi.png)"
    ]


### PR DESCRIPTION
The only change here is for correcting the link at the very end of the file to the correct URL of the REST API docs page. The link had become outdated. 