### PR TITLE
Small fixes

### DIFF
--- a/01-runtime-cli.ipynb
+++ b/01-runtime-cli.ipynb
@@ -1057,7 +1057,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-1.unsigned \\\n",
     "  --required-signer \"$LENDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_1 = $TX_1\""
@@ -1530,7 +1530,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-2.unsigned \\\n",
     "  --required-signer \"$LENDER_SKEY\" \\\n",
-    "  --timeout 600s"
+    "  --timeout 600"
    ]
   },
   {
@@ -1980,7 +1980,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-3.unsigned \\\n",
     "  --required-signer \"$BORROWER_SKEY\" \\\n",
-    "  --timeout 600s"
+    "  --timeout 600"
    ]
   },
   {

--- a/02-runtime-rest.ipynb
+++ b/02-runtime-rest.ipynb
@@ -944,7 +944,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-1.unsigned \\\n",
     "  --required-signer \"$LENDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_1 = $TX_1\""
@@ -1461,7 +1461,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-2.unsigned \\\n",
     "  --required-signer \"$LENDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_2 = $TX_2\""
@@ -1815,7 +1815,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-3.unsigned \\\n",
     "  --required-signer \"$BORROWER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_3 = $TX_3\""
@@ -2061,7 +2061,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-4.unsigned \\\n",
     "  --required-signer \"$BORROWER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_4 = $TX_4\""
@@ -2357,7 +2357,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-5.unsigned \\\n",
     "  --required-signer \"$LENDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_5 = $TX_5\""

--- a/04-escrow-rest.ipynb
+++ b/04-escrow-rest.ipynb
@@ -1124,7 +1124,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-1.unsigned \\\n",
     "  --required-signer \"$MEDIATOR_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_1 = $TX_1\""
@@ -1751,7 +1751,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-2.unsigned \\\n",
     "  --required-signer \"$BUYER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_2 = $TX_2\""
@@ -2202,7 +2202,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-3.unsigned \\\n",
     "  --required-signer \"$BUYER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_3 = $TX_3\""
@@ -2589,7 +2589,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-4.unsigned \\\n",
     "  --required-signer \"$SELLER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_4 = $TX_4\""
@@ -2959,7 +2959,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-5.unsigned \\\n",
     "  --required-signer \"$MEDIATOR_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_5 = $TX_5\""
@@ -3245,7 +3245,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-6.unsigned \\\n",
     "  --required-signer \"$SELLER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_6 = $TX_6\""

--- a/05-swap-rest.ipynb
+++ b/05-swap-rest.ipynb
@@ -791,7 +791,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-1.unsigned \\\n",
     "  --required-signer \"$ADA_PROVIDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_1 = $TX_1\""
@@ -1265,7 +1265,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-2.unsigned \\\n",
     "  --required-signer \"$ADA_PROVIDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_2 = $TX_2\""
@@ -1639,7 +1639,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-3.unsigned \\\n",
     "  --required-signer \"$USD_PROVIDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_3 = $TX_3\""
@@ -1959,7 +1959,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-4.unsigned \\\n",
     "  --required-signer \"$ADA_PROVIDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_4 = $TX_4\""
@@ -2198,7 +2198,7 @@
     "marlowe-cli transaction submit \\\n",
     "  --tx-body-file tx-5.unsigned \\\n",
     "  --required-signer \"$USD_PROVIDER_SKEY\" \\\n",
-    "  --timeout 600s \\\n",
+    "  --timeout 600 \\\n",
     "| sed -e 's/^TxId \"\\(.*\\)\"$/\\1/' \\\n",
     ")\n",
     "echo \"TX_5 = $TX_5\""

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
   };
 
   outputs = { self, flake-compat, flake-utils, nixpkgs, jupyenv, marlowe, cardano-world }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         mp = marlowe.packages.${system};


### PR DESCRIPTION
This solves some quick issues I had running on mac. 
I haven't solved the docker issue yet, were the node socket is not available in the HOST. As a temporary solution a mac user could create an alpine machine and copy some binaries to connect from docker to docker.

```
$ docker volume create runtime-bin
$ docker run -it --network=marlowe-starter-kit_default -v runtime-bin:/mnt/bin -v marlowe-starter-kit_shared:/mnt/shared alpine
$ wget -O /mnt/bin/marlowe-runtime-cli https://github.com/input-output-hk/marlowe-cardano/releases/download/runtime%40v0.0.2/marlowe-runtime-cli.x86_64-linux
$ wget -O /mnt/bin/marlowe-cli https://github.com/input-output-hk/marlowe-cardano/releases/download/runtime%40v0.0.2/marlowe-cli.x86_64-linux
$ chmod a+x /mnt/bin/*
$ export PATH=$PATH:/mnt/bin
$ export CARDANO_NODE_SOCKET_PATH=/mnt/shared/node.socket
$ export NETWORK=preprod
$ export CARDANO_TESTNET_MAGIC=1
$ export MARLOWE_RT_HOST=proxy
$ export MARLOWE_RT_PORT=3700
```