### PR TITLE
Fix flake show

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,9 +76,9 @@
       in rec {
         packages = {
           inherit jupyterlab;
-          marlowe-runtime-cli = mp.marlowe-runtime-cli;
-          marlowe-cli = mp.marlowe-cli;
-          marlowe-pipe = mp.marlowe.haskell.packages.marlowe-apps.components.exes.marlowe-pipe;
+          marlowe-runtime-cli = mp.ghc8107-marlowe-runtime-cli-exe-marlowe-runtime-cli;
+          marlowe-cli = mp.ghc8107-marlowe-cli-exe-marlowe-cli;
+          marlowe-pipe = mp.ghc8107-marlowe-apps-exe-marlowe-pipe;
         };
         packages.default = jupyterlab;
         apps = {


### PR DESCRIPTION
Now that I got the linux remote build working I noticed that `nix flake show` was not working in the current branch. The first time I saw it fail it explicitly told me that `malowe-cli` was a missing attribute, now it fails with this error (so much for reproducibility 🤷🏻 )

![Screenshot 2023-06-29 at 16 14 51](https://github.com/input-output-hk/marlowe-starter-kit/assets/2634059/517712cd-1c87-403b-af3d-1a180dae924e)

Using the `nix repl` I can see that the problem was indeed the missing package

![Screenshot 2023-06-29 at 16 14 01](https://github.com/input-output-hk/marlowe-starter-kit/assets/2634059/7664c9d9-a800-4b8a-88cd-e148c0b90121)


This does not seem to affect the `nix develop` shell as the proper package is listed there, but other flake projects that target this repository would get an error otherwise. We could eventually decide not to re-export the packages.

With these changes now `nix flake show` works as expected

![Screenshot 2023-06-29 at 16 13 41](https://github.com/input-output-hk/marlowe-starter-kit/assets/2634059/c859f59b-0172-4b81-b91d-720af3adc3f2)
