### PR TITLE
PLT-6805: Add local docker image

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -794,6 +794,21 @@
         "type": "github"
       }
     },
+    "blank_6": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
     "byron-chain": {
       "flake": false,
       "locked": {
@@ -1249,6 +1264,21 @@
         "owner": "haskell",
         "ref": "3.6",
         "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "call-flake": {
+      "locked": {
+        "lastModified": 1687380775,
+        "narHash": "sha256-bmhE1TmrJG4ba93l9WQTLuYM53kwGQAjYHRvHOeuxWU=",
+        "owner": "divnix",
+        "repo": "call-flake",
+        "rev": "74061f6c241227cd05e79b702db9a300a2e4131a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "call-flake",
         "type": "github"
       }
     },
@@ -2367,6 +2397,25 @@
         "type": "github"
       }
     },
+    "devshell_23": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_89",
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1688380630,
+        "narHash": "sha256-8ilApWVb1mAi4439zS3iFeIT0ODlbrifm/fegWwgHjA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "f9238ec3d75cefbb2b42a44948c4e8fb1ae9a205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "devshell_3": {
       "locked": {
         "lastModified": 1636119665,
@@ -2634,6 +2683,37 @@
       "original": {
         "owner": "divnix",
         "ref": "0.2.0",
+        "repo": "dmerge",
+        "type": "github"
+      }
+    },
+    "dmerge_6": {
+      "inputs": {
+        "haumea": [
+          "std",
+          "haumea"
+        ],
+        "nixlib": [
+          "std",
+          "haumea",
+          "nixpkgs"
+        ],
+        "yants": [
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686862774,
+        "narHash": "sha256-ojGtRQ9pIOUrxsQEuEPerUkqIJEuod9hIflfNkY+9CE=",
+        "owner": "divnix",
+        "repo": "dmerge",
+        "rev": "9f7f7a8349d33d7bd02e0f2b484b1f076e503a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "ref": "0.2.1",
         "repo": "dmerge",
         "type": "github"
       }
@@ -4004,6 +4084,21 @@
         "type": "github"
       }
     },
+    "flake-utils_53": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_6": {
       "locked": {
         "lastModified": 1642700792,
@@ -5022,6 +5117,25 @@
         "type": "github"
       }
     },
+    "haumea_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_90"
+      },
+      "locked": {
+        "lastModified": 1685133229,
+        "narHash": "sha256-FePm/Gi9PBSNwiDFq3N+DWdfxFq0UKsVVTJS3cQPn94=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "34dd58385092a23018748b50f9b23de6266dffc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.2.2",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
     "heist": {
       "flake": false,
       "locked": {
@@ -5480,6 +5594,28 @@
         "nixlib": [
           "marlowe",
           "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
+    "incl_3": {
+      "inputs": {
+        "nixlib": [
+          "std",
+          "haumea",
           "nixpkgs"
         ]
       },
@@ -6533,6 +6669,25 @@
         "owner": "nlewo",
         "repo": "nix2container",
         "rev": "ebca8f58d450cae1a19c07701a5a8ae40afc9efc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "n2c_7": {
+      "inputs": {
+        "flake-utils": "flake-utils_53",
+        "nixpkgs": "nixpkgs_88"
+      },
+      "locked": {
+        "lastModified": 1687467666,
+        "narHash": "sha256-z9n7ATBXeDqz5a8+4HJ9fhU6KMyg7zZX0wrhLdVG7bQ=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "56e249151911e3d3928b578f5b6c01b16f55c308",
         "type": "github"
       },
       "original": {
@@ -9790,6 +9945,37 @@
         "type": "github"
       }
     },
+    "nixpkgs_88": {
+      "locked": {
+        "lastModified": 1677612629,
+        "narHash": "sha256-yC+9LfhfwOd5sXFW8TLnDmqVMNYiHXYPGy9BbdpRqfU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "111ca8e0378e88d9decaa1c6dd7597f35d8bc67f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_89": {
+      "locked": {
+        "lastModified": 1677383253,
+        "narHash": "sha256-UfpzWfSxkfXHnb4boXZNaKsAcUrZT9Hw+tao1oZxd08=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9952d6bc395f5841262b006fbace8dd7e143b634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_9": {
       "locked": {
         "lastModified": 1641521701,
@@ -9802,6 +9988,37 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs_90": {
+      "locked": {
+        "lastModified": 1681001314,
+        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_91": {
+      "locked": {
+        "lastModified": 1675940568,
+        "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6ccc4a59c3f1b56d039d93da52696633e641bc71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nomad": {
@@ -10006,6 +10223,21 @@
       }
     },
     "nosys_3": {
+      "locked": {
+        "lastModified": 1668010795,
+        "narHash": "sha256-JBDVBnos8g0toU7EhIIqQ1If5m/nyBqtHhL3sicdPwI=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "feade0141487801c71ff55623b421ed535dbdefa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
+    "nosys_4": {
       "locked": {
         "lastModified": 1668010795,
         "narHash": "sha256-JBDVBnos8g0toU7EhIIqQ1If5m/nyBqtHhL3sicdPwI=",
@@ -10504,6 +10736,23 @@
         "type": "github"
       }
     },
+    "paisano-tui_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681847764,
+        "narHash": "sha256-mdd7PJW1BZvxy0cIKsPfAO+ohVl/V7heE5ZTAHzTdv8=",
+        "owner": "paisano-nix",
+        "repo": "tui",
+        "rev": "3096bad91cae73ab8ab3367d31f8a143d248a244",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "ref": "0.1.1",
+        "repo": "tui",
+        "type": "github"
+      }
+    },
     "paisano_2": {
       "inputs": {
         "haumea": "haumea_2",
@@ -10531,6 +10780,33 @@
       "original": {
         "owner": "paisano-nix",
         "ref": "0.1.0",
+        "repo": "core",
+        "type": "github"
+      }
+    },
+    "paisano_3": {
+      "inputs": {
+        "call-flake": "call-flake",
+        "nixpkgs": [
+          "std",
+          "nixpkgs"
+        ],
+        "nosys": "nosys_4",
+        "yants": [
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688099125,
+        "narHash": "sha256-j6LMz00orEKZrQb14wRRw7kMLm+aj7zBJt05AY4UcRI=",
+        "owner": "paisano-nix",
+        "repo": "core",
+        "rev": "10270dc46532c947de473ee88c8f5a3346a396fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
         "repo": "core",
         "type": "github"
       }
@@ -10859,11 +11135,13 @@
         "flake-utils": "flake-utils",
         "jupyenv": "jupyenv",
         "marlowe": "marlowe",
+        "n2c": "n2c_7",
         "nixpkgs": [
           "marlowe",
           "iogx",
           "nixpkgs"
-        ]
+        ],
+        "std": "std_7"
       }
     },
     "rust-analyzer-src": {
@@ -11552,6 +11830,55 @@
         "type": "github"
       }
     },
+    "std_7": {
+      "inputs": {
+        "arion": [
+          "std",
+          "blank"
+        ],
+        "blank": "blank_6",
+        "devshell": "devshell_23",
+        "dmerge": "dmerge_6",
+        "haumea": "haumea_3",
+        "incl": "incl_3",
+        "makes": [
+          "std",
+          "blank"
+        ],
+        "microvm": [
+          "std",
+          "blank"
+        ],
+        "n2c": [
+          "n2c"
+        ],
+        "nixago": [
+          "std",
+          "blank"
+        ],
+        "nixpkgs": "nixpkgs_91",
+        "paisano": "paisano_3",
+        "paisano-tui": "paisano-tui_3",
+        "terranix": [
+          "std",
+          "blank"
+        ],
+        "yants": "yants_10"
+      },
+      "locked": {
+        "lastModified": 1689337213,
+        "narHash": "sha256-qa0B38ihDW1MuAshwgvlbkk3CgheWlvYr35oMpDrxJs=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "17dc4eb9587517397dad00617b020769fece3cfe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
+    },
     "stdlib": {
       "locked": {
         "lastModified": 1590026685,
@@ -11808,6 +12135,21 @@
       }
     },
     "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -12523,6 +12865,28 @@
         "owner": "divnix",
         "repo": "yants",
         "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
+        "type": "github"
+      }
+    },
+    "yants_10": {
+      "inputs": {
+        "nixpkgs": [
+          "std",
+          "haumea",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686863218,
+        "narHash": "sha256-kooxYm3/3ornWtVBNHM3Zh020gACUyFX2G0VQXnB+mk=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "8f0da0dba57149676aa4817ec0c880fbde7a648d",
         "type": "github"
       },
       "original": {

--- a/nix/starter-env/devshell.nix
+++ b/nix/starter-env/devshell.nix
@@ -1,0 +1,60 @@
+{ inputs, cell}: {
+  default = inputs.std.lib.dev.mkShell {
+
+    nixago = [
+    ];
+    commands = [
+        {
+            name = "marlowe-cli";
+            package = inputs.mp.ghc8107-marlowe-cli-exe-marlowe-cli;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "marlowe-finder";
+            package = inputs.mp.ghc8107-marlowe-apps-exe-marlowe-finder;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "marlowe-runtime-cli";
+            package = inputs.mp.ghc8107-marlowe-runtime-cli-exe-marlowe-runtime-cli;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "marlowe-pipe";
+            package = inputs.mp.ghc8107-marlowe-apps-exe-marlowe-pipe;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "marlowe-scaling";
+            package = inputs.mp.ghc8107-marlowe-apps-exe-marlowe-scaling;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "marlowe-oracle";
+            package = inputs.mp.ghc8107-marlowe-apps-exe-marlowe-oracle;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "cardano-address";
+            package = inputs.cp.cardano-address;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "cardano-cli";
+            package = inputs.cp.cardano-cli;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "cardano-wallet";
+            package = inputs.cp.cardano-wallet;
+            category = "1 - Marlowe + Cardano";
+        }
+        {
+            name = "jupyter";
+            help = "Jupyter notebook: https://docs.jupyter.org/en/latest/running.html";
+            package = inputs.jupyterlab;
+            category = "2 - starter kit";
+        }
+    ];
+  };
+}

--- a/nix/starter-env/oci-image.nix
+++ b/nix/starter-env/oci-image.nix
@@ -1,0 +1,67 @@
+{ inputs, pkgs }:
+let
+  inherit (inputs) self std n2c srcDir;
+  inherit (pkgs.lib) removePrefix mapAttrsToList mapAttrs;
+  inherit (pkgs.lib.strings) concatMapStrings;
+  inherit (self) operables;
+
+  # This task creates a /notebook folder in the docker image
+  # with the files required to run the starter kit notebook
+  setupNotebook = std.lib.ops.mkSetup
+    "setupNotebook"
+    [
+      {
+        regex = "/notebook";
+        mode = "0777";
+        uid = 0;
+        gid = 0;
+      }
+    ]
+    ''
+      mkdir -p $out/notebook
+
+      cp -r ${srcDir}/*.ipynb $out/notebook
+      cp -r ${srcDir}/images $out/notebook
+      cp -r ${srcDir}/mainnet $out/notebook
+      cp -r ${srcDir}/preprod $out/notebook
+      cp -r ${srcDir}/preview $out/notebook
+      # NOTE: This was an attempt to make a first build of the jupyter notebooks
+      #       but fails
+      # TODO: Try to fix or delete
+      # cd $out
+      # ${inputs.jupyterlab}/bin/jupyter-lab lab build
+    '';
+
+
+  images = {
+    marlowe-starter-kit = std.lib.ops.mkStandardOCI {
+      name = "marlowe-starter-kit";
+      tag = "latest";
+      operable = operables."marlowe-starter-kit" "notebook";
+      uid = "0";
+      gid = "0";
+      setup = [setupNotebook];
+      options = {
+        # We need to setup /usr/bin/env in order for webpack to work
+        copyToRoot = [ pkgs.dockerTools.usrBinEnv];
+      };
+      labels = {
+        description = "An image with the necesary tools to run the starter kit tutorials";
+        source = "https://github.com/input-output-hk/marlowe-starter-kit";
+        license = "Apache-2.0";
+      };
+    };
+  };
+
+  forAllImages = f: concatMapStrings (s: s + "\n") (mapAttrsToList f images);
+in
+images // {
+  all = {
+    copyToDockerDaemon = std.lib.ops.writeScript {
+      name = "copy-to-docker-daemon";
+      text = forAllImages (name: img:
+        "${n2c.skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${img} docker-daemon:${name}:latest"
+      );
+    };
+  };
+}

--- a/nix/starter-env/operable.nix
+++ b/nix/starter-env/operable.nix
@@ -1,0 +1,25 @@
+{ inputs, pkgs }:
+let
+  inherit (inputs) std extraP;
+  inherit (std.lib.ops) mkOperable;
+in
+{
+  marlowe-starter-kit = notebookDir: mkOperable
+    {
+      package = inputs.jupyterlab;
+      runtimeScript = ''
+        cd ${notebookDir}
+        ${inputs.jupyterlab}/bin/jupyter notebook --allow-root --ip='*' --NotebookApp.token="" --NotebookApp.password="" --port 8080 --no-browser
+      '';
+      runtimeInputs = extraP ++ [
+        pkgs.coreutils
+        pkgs.nodejs
+      ];
+    };
+}
+
+
+
+
+
+


### PR DESCRIPTION
This PR creates a docker image with the Jupyter notebooks to run alongside the current `docker-compose` orchestration. It solves the need of requiring the user to have jupyter notebook and the different cli tools in their host machine and the problem that affects Mac and Windows users that cannot connect to a node socket from the host.

### Related work

* PLT-6806: Modify the docker compose
  * This will remove the necessity of manually launching the image  
* PLT-6807: Update the notebooks
  * Together with the previous task, will need to clean up the scripts so that it works with docker, with nix shell in linux and in demeter run
* PLT-6808: Build the image as part of the CI (currently manually uploaded to personal github)
* PLT-6809: Update documentation
 
### Testing the image
I've uploaded the generated docker image to my personal github registry to facilitate non-linux user testing. In order to try the image you need to execute the following from the `marlowe-starter-kit` project dir:

```
$ export NETWORK=preprod
$ docker-compose up -d
$ docker run -p 8080:8080 -v $(pwd)/keys:/notebook/keys -v marlowe-starter-kit_shared:/ipc --network=marlowe-starter-kit_default ghcr.io/hrajchert/marlowe-starter-kit:latest
```

The image might take some time to build the jupyter labs assets, I've marked some TODO's in the nix file to try to fix this. 

After a while you should see:

```
[2023-07-21 18:31:29 jupyenv] needs to build JupyterLab.
[LabBuildApp] JupyterLab 3.6.1
[LabBuildApp] Building in /nix/store/xylb0fivhrh8m91mngmf7ir0629ydd2l-oci-setup-setupNotebook/notebook/.jupyter/lab/share/jupyter/lab
[LabBuildApp] Building jupyterlab assets (production, minimized)
[I 18:38:33.902 NotebookApp] Writing notebook server cookie secret to .jupyter/runtime/notebook_cookie_secret
[I 18:38:33.903 NotebookApp] Authentication of /metrics is OFF, since other authentication is disabled.
[W 18:38:35.173 NotebookApp] WARNING: The notebook server is listening on all IP addresses and not using encryption. This is not recommended.
[W 18:38:35.174 NotebookApp] WARNING: The notebook server is listening on all IP addresses and not using authentication. This is highly insecure and not recommended.
[W 18:38:36.622 NotebookApp] Loading JupyterLab as a classic notebook (v6) extension.
[C 18:38:36.622 NotebookApp] You must use Jupyter Server v1 to load JupyterLab as notebook extension. You have v2.4.0 installed.
    You can fix this by executing:
        pip install -U "jupyter-server<2.0.0"
[I 18:38:36.641 NotebookApp] Serving notebooks from local directory: /nix/store/xylb0fivhrh8m91mngmf7ir0629ydd2l-oci-setup-setupNotebook/notebook
[I 18:38:36.642 NotebookApp] Jupyter Notebook 6.5.3 is running at:
[I 18:38:36.642 NotebookApp] http://4e2958def80b:8080/
[I 18:38:36.642 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
```

And if you connect to [http://localhost:8080](http://localhost:8080) you should be able to see and use the notebook

In the notebooks you might need to manually modify the scripts until the rest of the related work is completed

```
export CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
export CARDANO_TESTNET_MAGIC=1

export MARLOWE_RT_HOST="proxy"
export MARLOWE_RT_PORT=3700

export MARLOWE_RT_WEBSERVER_HOST="web-server"
export MARLOWE_RT_WEBSERVER_PORT=3780
export MARLOWE_RT_WEBSERVER_URL="http://$MARLOWE_RT_WEBSERVER_HOST:$MARLOWE_RT_WEBSERVER_PORT"
```

### Building the image
To build the docker image it is required to be on a Linux machine and execute the following

```
$ nix run .#create-docker-images
```

I've also modified the nix shell to include expected commands (only available to Linux users)

```
$ nix develop
```